### PR TITLE
(Possible) bug fix about segmentation fault when using txn:commit()

### DIFF
--- a/DB.lua
+++ b/DB.lua
@@ -134,6 +134,7 @@ end
 
 function txn:commit()
     lmdb.errcheck('mdb_txn_commit', self.mdb_txn[0])
+    self.mdb_txn = nil
     self.pointer_record = {}
 end
 


### PR DESCRIPTION
Hi, 

I uploaded a (possible) bug fix about segmentation fault when using txn:commit(). 

I had a problem as in https://github.com/eladhoffer/lmdb.torch/issues/7. 

The example `test.lua` gives me a `segmentation fault`. 

After some searching and investigation, the use of `txn` in any situation gives me `segmentation fault` at the end of any script even after `db:close()` is successfully called. However, when I use `txn:abort()` for closing `txn`, it works normally (w/o `segmentation fault`); therefore, I concluded that some `txn` related variable is not released properly. 

Based on the explanations about the functions, `mdb_txn_commit` and `mdb_txn_abort` (in http://symas.com/mdb/doc/group__mdb.html#ga846fbd6f46105617ac9f4d76476f6597), I added a line in `commit()` function to look like `abort()` function for `txn`. 

This might be a palliative than the solution. It seems working for me. 

Best regards, 

Jaehyun.
